### PR TITLE
🤖 Simplify `hello-world` stub

### DIFF
--- a/exercises/practice/hello-world/hello-world.wren
+++ b/exercises/practice/hello-world/hello-world.wren
@@ -1,10 +1,10 @@
 //
-// This is only a SKELETON file for the 'Hello World' exercise. It's been provided as a
+// This is only a SKELETON file for the 'Hello, World!' exercise. It's been provided as a
 // convenience to get you started writing code faster.
 //
 
 class Hello {
   static world() {
-    Fiber.abort("Remove this statement and implement this function")
+    return "Goodbye, Mars!"
   }
 }


### PR DESCRIPTION
Simplify the `hello-world` exercise's stub. The goal of this is to make things easier for students to get started and to introduce as little syntax as possible.

See https://github.com/exercism/v3-launch/issues/46
