### PR TITLE
Add icons for key features

### DIFF
--- a/config.json
+++ b/config.json
@@ -20,32 +20,32 @@
   },
   "key_features": [
     {
-      "icon": "features-declarative",
+      "icon": "fun",
       "title": "Familiar",
       "content": "Wren uses a familiar, modern syntax familiar to many coming from JS or another C-like language."
     },
     {
-      "icon": "features-strongly-typed",
+      "icon": "small",
       "title": "Small",
       "content": "Wren's VM implementation is under 4,000 semicolons of readable and lovingly commented C code."
     },
     {
-      "icon": "features-lazy",
+      "icon": "fast",
       "title": "Fast",
       "content": "A single-pass compiler, tight byte-code, and compact objects keeps Wren fast on it's feet."
     },
     {
-      "icon": "features-functional",
+      "icon": "concurrency",
       "title": "Concurrent",
       "content": "Lightweight fibers let you organize your program into a flock of communicating coroutines."
     },
     {
-      "icon": "features-generic",
+      "icon": "embeddable",
       "title": "Embeddable",
       "content": "Easily embedded, no dependencies, a small standard lib, and easy-to-use C API."
     },
     {
-      "icon": "features-oop",
+      "icon": "interop",
       "title": "Class-based",
       "content": "Many scripting languages lack (or have unusual) object models. Wren places classes front and center."
     }


### PR DESCRIPTION
The icons for key features are now available, and `configlet lint` now requires that each key feature has a valid `icon` value.

This PR sets an initial icon for each key feature - feel free to change them however you want. You can see the list of available icons [here](https://github.com/exercism/docs/issues/189). Note that an icon can be used regardless of its name.

With the initial state of this PR, the key features look something like the below.

---

![fun](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fun.svg) Familiar
Wren uses a familiar, modern syntax familiar to many coming from JS or another C-like language.

![small](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/small.svg) Small
Wren's VM implementation is under 4,000 semicolons of readable and lovingly commented C code.

![fast](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/fast.svg) Fast
A single-pass compiler, tight byte-code, and compact objects keeps Wren fast on it's feet.

![concurrency](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/concurrency.svg) Concurrent
Lightweight fibers let you organize your program into a flock of communicating coroutines.

![embeddable](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/embeddable.svg) Embeddable
Easily embedded, no dependencies, a small standard lib, and easy-to-use C API.

![interop](https://raw.githubusercontent.com/exercism/website-icons/main/key-features/interop.svg) Class-based
Many scripting languages lack (or have unusual) object models. Wren places classes front and center.
