### PR TITLE
Adding optional error handling tests for Robot Simulator

### DIFF
--- a/exercises/practice/robot-simulator/.meta/proof.ci.wren
+++ b/exercises/practice/robot-simulator/.meta/proof.ci.wren
@@ -27,6 +27,9 @@ class Robot {
   bearing { _bearing }
   coordinates { _coords.toList }
   place(opts) {
+    if (! DIRECTIONS.contains(opts["direction"])) {
+      Fiber.abort("Invalid input")
+    }
     _bearing = opts["direction"]
     _coords = Vector.new(opts["x"], opts["y"])
   }
@@ -49,6 +52,8 @@ class Robot {
       right
     } else if (cmd == "L") {
       left
+    } else {
+      Fiber.abort("Invalid input")
     }
   }
 }

--- a/exercises/practice/robot-simulator/robot-simulator.spec.wren
+++ b/exercises/practice/robot-simulator/robot-simulator.spec.wren
@@ -43,15 +43,6 @@ Testie.test("Robot") { |do, skip|
       Expect.value(robot.bearing).toEqual("south")
       Expect.value(robot.coordinates).toEqual([-1, -1])
     }
-
-    skip.test("invalid robot bearing") {
-      var robot = Robot.new()
-
-      // Expect.value(InvalidInputError.prototype).toBeInstanceOf(Error)
-      // Expect.value(() => robot.place({ "direction": "crood", "x": 0, "y": 0 })).toThrow(
-      //   InvalidInputError
-      // )
-    }
   }
 
   do.describe("Rotating clockwise") {
@@ -244,6 +235,22 @@ Testie.test("Robot") { |do, skip|
 
       Expect.value(robot3.coordinates).toEqual([11, 5])
       Expect.value(robot3.bearing).toEqual("north")
+    }
+  }
+
+  do.describe("Error handling") {
+    skip.test("invalid robot bearing") {
+      var robot = Robot.new()
+      Expect.that {
+        robot.place({ "direction": "crood", "x": 0, "y": 0 })
+      }.abortsWith("Invalid input")
+    }
+
+    skip.test("invalid instruction") {
+      var robot = Robot.new()
+      Expect.that {
+        robot.evaluate("LAX")
+      }.abortsWith("Invalid input")
     }
   }
 }


### PR DESCRIPTION
This implements the commented-out "invalid robot bearing" test as well as the "invalid instruction" optional test [mentioned in the canonical data](https://github.com/exercism/problem-specifications/blob/main/exercises/robot-simulator/canonical-data.json#L5)