### PR TITLE
Fix inconsistent test formatting in two-fer

### DIFF
--- a/exercises/practice/two-fer/two-fer.spec.wren
+++ b/exercises/practice/two-fer/two-fer.spec.wren
@@ -2,7 +2,6 @@ import "./two-fer" for TwoFer
 import "wren-testie/testie" for Testie, Expect
 
 Testie.test("TwoFer") { |do, skip|
-
   do.test("no name given") {
     Expect.value(TwoFer.twoFer()).toEqual("One for you, one for me.")
   }


### PR DESCRIPTION
It looks like this newline is not present in other test suites.