### PR TITLE
custom-set: Synchronize method name in skeleton with the spec

### DIFF
--- a/exercises/practice/custom-set/custom-set.wren
+++ b/exercises/practice/custom-set/custom-set.wren
@@ -3,7 +3,7 @@ class CustomSet {
     Fiber.abort("Remove this statement and implement this function")
   }
 
-  empty() {
+  isEmpty {
     Fiber.abort("Remove this statement and implement this function")
   }
 


### PR DESCRIPTION
Currently the skeleton has a method called `empty()` but the spec tests for `isEmpty`