### PR TITLE
Formatting inconsistency in custom-set spec

### DIFF
--- a/exercises/practice/custom-set/custom-set.spec.wren
+++ b/exercises/practice/custom-set/custom-set.spec.wren
@@ -117,6 +117,7 @@ Testie.test("CustomSet") { |do, skip|
       var actual = CustomSet.new([1, 2, 3]).eql(CustomSet.new([1, 2, 4]))
       Expect.value(actual).toBe(false)
     }
+
     skip.test("set is not equal to larger set with same elements") {
       var actual = CustomSet.new([1, 2, 3]).eql(CustomSet.new([1, 2, 3, 4]))
       Expect.value(actual).toBe(false)


### PR DESCRIPTION
Sorry, I didn't catch this earlier.