### PR TITLE
Minesweeper - Enable the first test by default

### DIFF
--- a/exercises/practice/minesweeper/minesweeper.spec.wren
+++ b/exercises/practice/minesweeper/minesweeper.spec.wren
@@ -2,7 +2,7 @@ import "./minesweeper" for Minesweeper
 import "wren-testie/testie" for Testie, Expect
 
 Testie.test("Minesweeper") { |do, skip|
-  skip.test("handles no rows") {
+  do.test("handles no rows") {
     Expect.value(Minesweeper.annotate([])).toEqual([])
   }
 


### PR DESCRIPTION
All of the other exercises have the first test enabled by default, this brings minesweeper in line