### PR TITLE
(chore) bump wren-console used for CI to v0.3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,17 @@ jobs:
         with:
           repository: joshgoebel/wren-console
           path: wren-console
-          ref: v0.3.0
+          ref: v0.3.1
+      - name: Pin dependencies
+        shell: bash
+        run: |
+          cat WREN_ESSENTIALS >> $GITHUB_ENV
       - name: Checkout wren-essentials
         uses: actions/checkout@v2
         with:
           repository: joshgoebel/wren-essentials
           path: wren-console/deps/wren-essentials
-          ref: v0.2.0
+          ref: ${{env.WREN_ESSENTIALS}}
       - name: Build wren-console
         run: |
           cd wren-console

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Pin dependencies
         shell: bash
         run: |
-          cat WREN_ESSENTIALS >> $GITHUB_ENV
+          cat wren-console/WREN_ESSENTIALS >> $GITHUB_ENV
       - name: Checkout wren-essentials
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
It seems our Wren infrastructure is a bit behind so I'm going to create a few PRs to get us on v0.3.1 across the board.  I'll leave them in draft until ready (unless I need to bump them to get the CI to run)...