### PR TITLE
Stub file declares wrong method name

### DIFF
--- a/exercises/practice/difference-of-squares/difference-of-squares.wren
+++ b/exercises/practice/difference-of-squares/difference-of-squares.wren
@@ -1,5 +1,5 @@
 class Squares {
-  static squareOfSums(n) {
+  static squareOfSum(n) {
     Fiber.abort("Remove this statement and implement this function")
   }
   


### PR DESCRIPTION
Discovered in online editor
```
Squares metaclass does not implement 'squareOfSum(_)'.
at test(_,_) block argument (./difference-of-squares.spec.wren line 7)
```