### PR TITLE
list-ops: 2 "new" constructors, different signatures

### DIFF
--- a/exercises/practice/list-ops/list-ops.spec.wren
+++ b/exercises/practice/list-ops/list-ops.spec.wren
@@ -13,6 +13,11 @@ Testie.test("ListOps") { |do, skip|
       Expect.value(list1.toList).toEqual([1, 2, 3, 4])
     }
 
+    do.test("can be instantiated with no elements") {
+      var list1 = ListOps.new()
+      Expect.value(list1.toList).toEqual([])
+    }
+
     skip.test("can add an item") {
       var list1 = ListOps.new([1, 2])
       list1.add(3)

--- a/exercises/practice/list-ops/list-ops.wren
+++ b/exercises/practice/list-ops/list-ops.wren
@@ -3,6 +3,11 @@ class ListOps {
     Fiber.abort("Remove this statement and implement this class")
   }
 
+  // no-arguments constructor
+  construct new() {
+    Fiber.abort("Remove this statement and implement this class")
+  }
+
   // return the items as a List
   toList {
     Fiber.abort("Remove this statement and implement this method")


### PR DESCRIPTION
I think this is the first exercise that we overload "new".

closes #113