### PR TITLE
Normalize practice exercise names

### DIFF
--- a/config.json
+++ b/config.json
@@ -79,7 +79,7 @@
       },
       {
         "slug": "leap",
-        "name": "Leap Years",
+        "name": "Leap",
         "uuid": "e95f1ade-287a-4391-ae28-82e037f39628",
         "prerequisites": [],
         "difficulty": 1,
@@ -529,7 +529,7 @@
       },
       {
         "slug": "run-length-encoding",
-        "name": "Run Length Encoding",
+        "name": "Run-Length Encoding",
         "uuid": "642ddb58-625b-43b8-b7b9-3e0025dbd989",
         "prerequisites": [],
         "difficulty": 4,


### PR DESCRIPTION
We have added explicit exercise titles to the metadata.toml files in problem-specifications.

This updates the exercise names to match the values in this field.