### PR TITLE
Forego meetup

### DIFF
--- a/config.json
+++ b/config.json
@@ -740,6 +740,9 @@
         "prerequisites": [],
         "difficulty": 7
       }
+    ],
+    "foregone": [
+      "meetup"
     ]
   },
   "key_features": [


### PR DESCRIPTION
wren doesn't have any DateTime library. This exercise demands to know the weekday name of an arbitrary date.