### PR TITLE
Rename Two-Fer

### DIFF
--- a/config.json
+++ b/config.json
@@ -76,7 +76,7 @@
       },
       {
         "slug": "two-fer",
-        "name": "Two Fer",
+        "name": "Two-Fer",
         "uuid": "42e242e7-03c7-4989-a418-770ee5805008",
         "practices": [],
         "prerequisites": [],


### PR DESCRIPTION
Now all practice exercises have names consistent with problem-specifications metadata

https://github.com/exercism/problem-specifications/blob/main/exercises/two-fer/metadata.toml

[no important files changed]