### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/protein-translation/.docs/instructions.append.md
+++ b/exercises/practice/protein-translation/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 If an invalid character or codon is encountered _during_ translation, it should `throw` an error with the message `Invalid codon`.
 
 ```javascript

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,9 +1,13 @@
 # Instructions append
 
+## Implementation
+
 A queen must be placed on a valid position on the board.
 Two queens cannot share the same position.
 
-If a position has not been given, the queens are at their [default starting positions](https://en.wikipedia.org/wiki/Rules_of_chess#Initial_setup). That's the bottom row (1) for the white queen and the top row (8) for the black queen. Both queens start in the fourth column (d).
+If a position has not been given, the queens are at their [default starting positions](https://en.wikipedia.org/wiki/Rules_of_chess#Initial_setup).
+That's the bottom row (1) for the white queen and the top row (8) for the black queen.
+Both queens start in the fourth column (d).
 
 ```text
   a b c d e f g h

--- a/exercises/practice/resistor-color/.docs/instructions.append.md
+++ b/exercises/practice/resistor-color/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions append
 
-Although the color names are capitalised in the description, the function colorCode will always be called with the lowercase equivalent, e.g brown instead of Brown
+## Implementation
+
+Although the color names are capitalised in the description, the function colorCode will always be called with the lowercase equivalent, e.g brown instead of Brown.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.